### PR TITLE
Arcana double door functionality

### DIFF
--- a/src/main/java/divinerpg/objects/blocks/arcana/BlockArcanaDoor.java
+++ b/src/main/java/divinerpg/objects/blocks/arcana/BlockArcanaDoor.java
@@ -50,6 +50,29 @@ public class BlockArcanaDoor extends BlockModDoor {
             worldIn.setBlockState(blockpos, state, 10);
             worldIn.markBlockRangeForRenderUpdate(blockpos, pos);
             worldIn.playEvent(player, ((Boolean) state.getValue(OPEN)).booleanValue() ? 1005 : 1011, pos, 0);
+
+            BlockPos[] adjacent = {
+                    blockpos.north(),
+                    blockpos.east(),
+                    blockpos.south(),
+                    blockpos.west()
+            };
+
+            for(BlockPos adjacentPos: adjacent) {
+                IBlockState adjacentBlockState =  worldIn.getBlockState(adjacentPos);
+                if (adjacentBlockState.getBlock() != this) {
+                    continue;
+                }
+                else if(!player.capabilities.isCreativeMode && adjacentBlockState.getProperties().get(OPEN).equals(true)) {
+                    break;
+                }
+                else {
+                    adjacentBlockState = iblockstate.cycleProperty(OPEN);
+                    worldIn.setBlockState(adjacentPos, adjacentBlockState, 10);
+                    worldIn.markBlockRangeForRenderUpdate(adjacentPos, adjacentPos);
+                    worldIn.playEvent(player, ((Boolean) state.getValue(OPEN)).booleanValue() ? 1005 : 1011, adjacentPos, 0);
+                }
+            }
             return true;
         }
     }

--- a/src/main/java/divinerpg/objects/blocks/arcana/BlockArcanaDoor.java
+++ b/src/main/java/divinerpg/objects/blocks/arcana/BlockArcanaDoor.java
@@ -71,6 +71,7 @@ public class BlockArcanaDoor extends BlockModDoor {
                     worldIn.setBlockState(adjacentPos, adjacentBlockState, 10);
                     worldIn.markBlockRangeForRenderUpdate(adjacentPos, adjacentPos);
                     worldIn.playEvent(player, ((Boolean) state.getValue(OPEN)).booleanValue() ? 1005 : 1011, adjacentPos, 0);
+                    return true;
                 }
             }
             return true;


### PR DESCRIPTION
Adds arcana double door functionality as discussed in #52 

https://youtu.be/sfskMJ0y4qI
Note that this does not take into account how the doors are facing, and will open up any two doors of the same kind that are next to each other. Luckily, in Arcana the only naturally occurring double doors (the rooms with the four degraded double doors) face like double doors (i.e. both open outwards), and they are unobtainable elsewhere so that is a lower priority issue.

Only two doors will open at once because the method returns the moment it opens another one.

Finally only doors of the same kind can open as double doors (shown in the video with the sludge door, which is manually placed).