### PR TITLE
Iceika snowflake generates inside chest

### DIFF
--- a/src/main/java/divinerpg/objects/blocks/iceika/BlockFrostedChest.java
+++ b/src/main/java/divinerpg/objects/blocks/iceika/BlockFrostedChest.java
@@ -27,12 +27,10 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class BlockFrostedChest extends BlockModChest {
-    private boolean dropsSnowflake;
 
-    public BlockFrostedChest(String name, boolean dropsSnowFlake) {
-        super(name, Material.WOOD);
+    public BlockFrostedChest(String name) {
+        super(name, Material.GLASS);
         setSoundType(SoundType.GLASS);
-        this.dropsSnowflake = dropsSnowFlake;
     }
 
     public int getGuiID() {
@@ -49,23 +47,8 @@ public class BlockFrostedChest extends BlockModChest {
     public void harvestBlock(World world, EntityPlayer player, BlockPos pos, IBlockState state, @Nullable TileEntity te,
             ItemStack stack) {
         super.harvestBlock(world, player, pos, state, te, stack);
-        if (this.dropsSnowflake && player instanceof EntityPlayerMP) {
+        if (player instanceof EntityPlayerMP) {
             ModTriggers.DIVINERPG_BLOCK.trigger((EntityPlayerMP) player, this);
-        }
-    }
-
-    @Override
-    public void getDrops(NonNullList<ItemStack> drops, IBlockAccess world, BlockPos pos, IBlockState state,
-            int fortune) {
-        Random rand = new Random();
-        if (this.dropsSnowflake) {
-            if (rand.nextInt(20) == 0) {
-                drops.add(new ItemStack(ModBlocks.decorativeFrostedChest, 1, 0));
-            } else {
-                drops.add(new ItemStack(ModItems.snowflake, 1, 0));
-            }
-        } else {
-            drops.add(new ItemStack(ModBlocks.decorativeFrostedChest, 1, 0));
         }
     }
 

--- a/src/main/java/divinerpg/proxy/ClientProxy.java
+++ b/src/main/java/divinerpg/proxy/ClientProxy.java
@@ -137,8 +137,7 @@ public class ClientProxy extends CommonProxy {
     public void registerItemRenderer(final Item item, final int meta, final String id) {
         ModelLoader.setCustomModelResourceLocation(item, meta,
                 new ModelResourceLocation(item.getRegistryName(), "inventory"));
-        if (item.equals(Item.getItemFromBlock(ModBlocks.frostedChest))
-                || item.equals(Item.getItemFromBlock(ModBlocks.decorativeFrostedChest))) {
+        if (item.equals(Item.getItemFromBlock(ModBlocks.frostedChest))) {
             item.setTileEntityItemStackRenderer(new RenderItemFrostedChest());
         } else if (item.equals(Item.getItemFromBlock(ModBlocks.presentBox))) {
             item.setTileEntityItemStackRenderer(new RenderItemPresentBox());

--- a/src/main/java/divinerpg/registry/ModBlocks.java
+++ b/src/main/java/divinerpg/registry/ModBlocks.java
@@ -306,9 +306,7 @@ public class ModBlocks {
 
     public static Block icyStone = new BlockModUnbreakable("icy_stone");
     public static Block icyBricks = new BlockModUnbreakable("icy_bricks");
-    public static Block frostedChest = new BlockFrostedChest("frosted_chest", true).setHardness(2.5F);
-    public static Block decorativeFrostedChest = new BlockFrostedChest("decorative_frosted_chest", false)
-            .setHardness(2.5F);
+    public static Block frostedChest = new BlockFrostedChest("frosted_chest").setHardness(2.5F);
     public static Block rollumSpawner = new BlockModSpawner("rollum_spawner", "rollum");
     public static Block frostArcherSpawner = new BlockModSpawner("frost_archer_spawner", "frost_archer");
     public static Block snowBricks = new BlockMod("snow_bricks", 6.0F);

--- a/src/main/resources/assets/divinerpg/loot_tables/chests/iceika_chest.json
+++ b/src/main/resources/assets/divinerpg/loot_tables/chests/iceika_chest.json
@@ -1,6 +1,29 @@
 {
     "pools": [
         {
+            "name":"divinerpg:iceika_chest_snowflake",
+            "rolls": {
+                "min": 1,
+                "max": 1
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "divinerpg:snowflake",
+                    "weight": 14,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 1
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
             "name":"divinerpg:iceika_chest",
             "rolls": {
                 "min": 1,

--- a/src/main/resources/assets/divinerpg/loot_tables/chests/iceika_chest.json
+++ b/src/main/resources/assets/divinerpg/loot_tables/chests/iceika_chest.json
@@ -10,7 +10,7 @@
                 {
                     "type": "item",
                     "name": "divinerpg:snowflake",
-                    "weight": 14,
+                    "weight": 1,
                     "functions": [
                         {
                             "function": "set_count",


### PR DESCRIPTION
As discussed in #ideas channel on discord

The snowflake generates inside the chest now (along with the peppermints), and the chest just drops itself + contents when broken. Currently one and only one snowflake will generate per chest, so there is no change in amount.

As a result, the "decorative frosted chest" block (the same but dropped itself instead of the snowflake) is now removed.

Since "decorative frosted chest" was under a different block ID though, the nbts for the iceika huts that did have them need to be changed. (The dungeons are fine as they used the original frosted chest.)