### PR TITLE
Remove IHasModel

### DIFF
--- a/src/main/java/divinerpg/events/RegistryHandler.java
+++ b/src/main/java/divinerpg/events/RegistryHandler.java
@@ -1,14 +1,18 @@
 package divinerpg.events;
 
 import divinerpg.Config;
+import divinerpg.client.render.*;
+import divinerpg.objects.blocks.BlockStatue;
 import divinerpg.registry.ModBlocks;
 import divinerpg.registry.ModItems;
 import divinerpg.registry.ModLiquids;
 import divinerpg.registry.ModSpawns;
-import divinerpg.utils.IHasModel;
 import net.minecraft.block.Block;
+import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemBlock;
 import net.minecraftforge.client.event.ModelRegistryEvent;
+import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -50,15 +54,37 @@ public class RegistryHandler {
     @SubscribeEvent
     public static void onModelRegister(ModelRegistryEvent event) {
         for (Item item : ModItems.ITEMS) {
-            if (item instanceof IHasModel) {
-                ((IHasModel) item).registerModels();
+            registerItemModel(item);
+
+            //FIXME: there may be a better way
+            if (item.equals(Item.getItemFromBlock(ModBlocks.frostedChest))) {
+                item.setTileEntityItemStackRenderer(new RenderItemFrostedChest());
+            } else if (item.equals(Item.getItemFromBlock(ModBlocks.presentBox))) {
+                item.setTileEntityItemStackRenderer(new RenderItemPresentBox());
+            } else if (item.equals(Item.getItemFromBlock(ModBlocks.boneChest))) {
+                item.setTileEntityItemStackRenderer(new RenderItemBoneChest());
+            } else if (item.equals(Item.getItemFromBlock(ModBlocks.demonFurnace))) {
+                item.setTileEntityItemStackRenderer(new RenderItemDemonFurnace());
+            } else if (item instanceof ItemBlock && ((ItemBlock) item).getBlock() instanceof BlockStatue) {
+                item.setTileEntityItemStackRenderer(new RenderItemStatue());
+            } else if (item.equals(Item.getItemFromBlock(ModBlocks.edenChest))) {
+                item.setTileEntityItemStackRenderer(new RenderItemEdenChest());
+            } else if (item.equals(Item.getItemFromBlock(ModBlocks.arcaniumExtractor))) {
+                item.setTileEntityItemStackRenderer(new RenderItemArcaniumExtractor());
+            } else if (item.equals(Item.getItemFromBlock(ModBlocks.dramixAltar))) {
+                item.setTileEntityItemStackRenderer(new RenderItemDramixAltar());
+            } else if (item.equals(Item.getItemFromBlock(ModBlocks.parasectaAltar))) {
+                item.setTileEntityItemStackRenderer(new RenderItemParasectaAltar());
             }
         }
 
         for (Block block : ModBlocks.BLOCKS) {
-            if (block instanceof IHasModel) {
-                ((IHasModel) block).registerModels();
-            }
+            registerItemModel(Item.getItemFromBlock(block));
         }
     }
+
+    public static void registerItemModel(Item item) {
+        ModelLoader.setCustomModelResourceLocation(item, 0, new ModelResourceLocation(item.getRegistryName(), "inventory"));
+    }
+
 }

--- a/src/main/java/divinerpg/objects/blocks/BlockMod.java
+++ b/src/main/java/divinerpg/objects/blocks/BlockMod.java
@@ -1,26 +1,14 @@
 package divinerpg.objects.blocks;
 
-import java.util.Random;
-
-import divinerpg.DivineRPG;
 import divinerpg.enums.EnumBlockType;
-import divinerpg.enums.EnumToolType;
 import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModBlocks;
 import divinerpg.registry.ModItems;
-import divinerpg.utils.IHasModel;
 import net.minecraft.block.Block;
-import net.minecraft.block.material.MapColor;
-import net.minecraft.block.material.Material;
-import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.MathHelper;
-import net.minecraft.world.IBlockAccess;
 
-public class BlockMod extends Block implements IHasModel {
+public class BlockMod extends Block  {
 
     public BlockMod(String name, float hardness) {
         this(EnumBlockType.ROCK, name, hardness);
@@ -45,10 +33,5 @@ public class BlockMod extends Block implements IHasModel {
 
         ModBlocks.BLOCKS.add(this);
         ModItems.ITEMS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
-    }
-
-    @Override
-    public void registerModels() {
-        DivineRPG.proxy.registerItemRenderer(Item.getItemFromBlock(this), 0, "inventory");
     }
 }

--- a/src/main/java/divinerpg/objects/blocks/BlockModChest.java
+++ b/src/main/java/divinerpg/objects/blocks/BlockModChest.java
@@ -4,7 +4,6 @@ import divinerpg.DivineRPG;
 import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModBlocks;
 import divinerpg.registry.ModItems;
-import divinerpg.utils.IHasModel;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.BlockHorizontal;
 import net.minecraft.block.material.Material;
@@ -15,7 +14,6 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.InventoryHelper;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -32,7 +30,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public abstract class BlockModChest extends BlockContainer implements IHasModel {
+public abstract class BlockModChest extends BlockContainer  {
     protected static final AxisAlignedBB AABB_BLOCK = new AxisAlignedBB(0.0625D, 0.0D, 0.0625D, 0.9375D, 0.875D,
             0.9375D);
     public static final PropertyDirection FACING = BlockHorizontal.FACING;
@@ -157,10 +155,5 @@ public abstract class BlockModChest extends BlockContainer implements IHasModel 
     @Override
     public IBlockState withRotation(IBlockState state, Rotation rot) {
         return state.withProperty(FACING, rot.rotate(state.getValue(FACING)));
-    }
-
-    @Override
-    public void registerModels() {
-        DivineRPG.proxy.registerItemRenderer(Item.getItemFromBlock(this), 0, "inventory");
     }
 }

--- a/src/main/java/divinerpg/objects/blocks/BlockModCrop.java
+++ b/src/main/java/divinerpg/objects/blocks/BlockModCrop.java
@@ -3,14 +3,11 @@ package divinerpg.objects.blocks;
 import java.util.ArrayList;
 import java.util.List;
 
-import divinerpg.DivineRPG;
 import divinerpg.registry.ModBlocks;
 import divinerpg.registry.ModItems;
-import divinerpg.utils.IHasModel;
 import net.minecraft.block.BlockCrops;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
@@ -18,7 +15,7 @@ import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-public class BlockModCrop extends BlockCrops implements IHasModel {
+public class BlockModCrop extends BlockCrops  {
 
     /**
      * Contains stages of growth
@@ -54,11 +51,6 @@ public class BlockModCrop extends BlockCrops implements IHasModel {
     public boolean canPlaceBlockAt(World worldIn, BlockPos pos) {
         IBlockState soil = worldIn.getBlockState(pos.down());
         return worldIn.getBlockState(pos).getBlock().isReplaceable(worldIn, pos) && soil.getBlock() == Blocks.FARMLAND;
-    }
-
-    @Override
-    public void registerModels() {
-        DivineRPG.proxy.registerItemRenderer(Item.getItemFromBlock(this), 0, "inventory");
     }
 
     @Override

--- a/src/main/java/divinerpg/objects/blocks/BlockModDoor.java
+++ b/src/main/java/divinerpg/objects/blocks/BlockModDoor.java
@@ -2,12 +2,10 @@ package divinerpg.objects.blocks;
 
 import java.util.Random;
 
-import divinerpg.DivineRPG;
 import divinerpg.objects.items.base.ItemBlockDoor;
 import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModBlocks;
 import divinerpg.registry.ModItems;
-import divinerpg.utils.IHasModel;
 import net.minecraft.block.BlockDoor;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
@@ -21,7 +19,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
 
-public class BlockModDoor extends BlockDoor implements IHasModel {
+public class BlockModDoor extends BlockDoor  {
 
     public BlockModDoor(String name, Material materialIn, float hardness) {
         super(materialIn);
@@ -61,10 +59,5 @@ public class BlockModDoor extends BlockDoor implements IHasModel {
     public ItemStack getPickBlock(IBlockState state, RayTraceResult target, World world, BlockPos pos,
             EntityPlayer player) {
         return new ItemStack(this);
-    }
-
-    @Override
-    public void registerModels() {
-        DivineRPG.proxy.registerItemRenderer(Item.getItemFromBlock(this), 0, "inventory");
     }
 }

--- a/src/main/java/divinerpg/objects/blocks/BlockModFire.java
+++ b/src/main/java/divinerpg/objects/blocks/BlockModFire.java
@@ -6,7 +6,6 @@ import divinerpg.Config;
 import divinerpg.DivineRPG;
 import divinerpg.registry.ModBlocks;
 import divinerpg.registry.ModItems;
-import divinerpg.utils.IHasModel;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockFire;
 import net.minecraft.block.state.IBlockState;
@@ -15,7 +14,7 @@ import net.minecraft.item.ItemBlock;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
-public class BlockModFire extends BlockFire implements IHasModel {
+public class BlockModFire extends BlockFire  {
 
     public BlockModFire(String name) {
         super();
@@ -50,11 +49,6 @@ public class BlockModFire extends BlockFire implements IHasModel {
     @Override
     public void onBlockAdded(World world, BlockPos pos, IBlockState state) {
         lightPortal(world, pos, state);
-    }
-
-    @Override
-    public void registerModels() {
-        DivineRPG.proxy.registerItemRenderer(Item.getItemFromBlock(this), 0, "inventory");
     }
 
     @Override

--- a/src/main/java/divinerpg/objects/blocks/BlockModFurnace.java
+++ b/src/main/java/divinerpg/objects/blocks/BlockModFurnace.java
@@ -7,7 +7,6 @@ import divinerpg.objects.blocks.tile.entity.TileEntityModFurnace;
 import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModBlocks;
 import divinerpg.registry.ModItems;
-import divinerpg.utils.IHasModel;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockHorizontal;
 import net.minecraft.block.material.Material;
@@ -19,7 +18,6 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.inventory.InventoryHelper;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -35,7 +33,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public abstract class BlockModFurnace extends Block implements IHasModel {
+public abstract class BlockModFurnace extends Block  {
     public static final PropertyDirection FACING = BlockHorizontal.FACING;
     public static boolean keepInventory;
     protected boolean isBurning;
@@ -209,10 +207,5 @@ public abstract class BlockModFurnace extends Block implements IHasModel {
     @SuppressWarnings("deprecation")
     public IBlockState withRotation(IBlockState state, Rotation rot) {
         return state.withProperty(FACING, rot.rotate(state.getValue(FACING)));
-    }
-
-    @Override
-    public void registerModels() {
-        DivineRPG.proxy.registerItemRenderer(Item.getItemFromBlock(this), 0, "inventory");
     }
 }

--- a/src/main/java/divinerpg/objects/blocks/BlockModLadder.java
+++ b/src/main/java/divinerpg/objects/blocks/BlockModLadder.java
@@ -4,12 +4,11 @@ import divinerpg.DivineRPG;
 import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModBlocks;
 import divinerpg.registry.ModItems;
-import divinerpg.utils.IHasModel;
 import net.minecraft.block.BlockLadder;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 
-public class BlockModLadder extends BlockLadder implements IHasModel {
+public class BlockModLadder extends BlockLadder  {
     public BlockModLadder(String name) {
         setUnlocalizedName(name);
         setRegistryName(name);
@@ -18,10 +17,5 @@ public class BlockModLadder extends BlockLadder implements IHasModel {
 
         ModBlocks.BLOCKS.add(this);
         ModItems.ITEMS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
-    }
-
-    @Override
-    public void registerModels() {
-        DivineRPG.proxy.registerItemRenderer(Item.getItemFromBlock(this), 0, "inventory");
     }
 }

--- a/src/main/java/divinerpg/objects/blocks/BlockModLeaves.java
+++ b/src/main/java/divinerpg/objects/blocks/BlockModLeaves.java
@@ -2,11 +2,9 @@ package divinerpg.objects.blocks;
 
 import java.util.Random;
 
-import divinerpg.DivineRPG;
 import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModBlocks;
 import divinerpg.registry.ModItems;
-import divinerpg.utils.IHasModel;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockLeaves;
 import net.minecraft.block.BlockPlanks;
@@ -24,7 +22,7 @@ import net.minecraftforge.common.IShearable;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class BlockModLeaves extends BlockLeaves implements IShearable, IHasModel {
+public class BlockModLeaves extends BlockLeaves implements IShearable {
     private Block sapling;
 
     public BlockModLeaves(String name, float hardness) {
@@ -95,11 +93,6 @@ public class BlockModLeaves extends BlockLeaves implements IShearable, IHasModel
     @Override
     protected ItemStack getSilkTouchDrop(IBlockState state) {
         return new ItemStack(Item.getItemFromBlock(this));
-    }
-
-    @Override
-    public void registerModels() {
-        DivineRPG.proxy.registerItemRenderer(Item.getItemFromBlock(this), 0, "inventory");
     }
 
     @Override

--- a/src/main/java/divinerpg/objects/blocks/BlockModLog.java
+++ b/src/main/java/divinerpg/objects/blocks/BlockModLog.java
@@ -1,17 +1,14 @@
 package divinerpg.objects.blocks;
 
-import divinerpg.DivineRPG;
 import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModBlocks;
 import divinerpg.registry.ModItems;
-import divinerpg.utils.IHasModel;
 import net.minecraft.block.BlockLog;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 
-public class BlockModLog extends BlockLog implements IHasModel {
+public class BlockModLog extends BlockLog  {
 
 	public BlockModLog(String name) {
 		super();
@@ -49,20 +46,15 @@ public class BlockModLog extends BlockLog implements IHasModel {
 	@Override
 	public IBlockState getStateFromMeta(int meta) {
 		switch (meta) {
-		case 0:
-			return getDefaultState().withProperty(LOG_AXIS, EnumAxis.Y);
-		case 4:
-			return getDefaultState().withProperty(LOG_AXIS, EnumAxis.X);
-		case 8:
-			return getDefaultState().withProperty(LOG_AXIS, EnumAxis.Z);
-		case 12:
-		default:
-			return getDefaultState().withProperty(LOG_AXIS, EnumAxis.NONE);
+			case 0:
+				return getDefaultState().withProperty(LOG_AXIS, EnumAxis.Y);
+			case 4:
+				return getDefaultState().withProperty(LOG_AXIS, EnumAxis.X);
+			case 8:
+				return getDefaultState().withProperty(LOG_AXIS, EnumAxis.Z);
+			case 12:
+			default:
+				return getDefaultState().withProperty(LOG_AXIS, EnumAxis.NONE);
 		}
-	}
-
-	@Override
-	public void registerModels() {
-		DivineRPG.proxy.registerItemRenderer(Item.getItemFromBlock(this), 0, "inventory");
 	}
 }

--- a/src/main/java/divinerpg/objects/blocks/BlockModPortal.java
+++ b/src/main/java/divinerpg/objects/blocks/BlockModPortal.java
@@ -12,7 +12,6 @@ import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModBlocks;
 import divinerpg.registry.ModItems;
 import divinerpg.utils.DivineTeleporter;
-import divinerpg.utils.IHasModel;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockBreakable;
 import net.minecraft.block.material.Material;
@@ -41,7 +40,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class BlockModPortal extends BlockBreakable implements IHasModel {
+public class BlockModPortal extends BlockBreakable {
 
     public static final PropertyEnum<EnumFacing.Axis> AXIS = PropertyEnum.<EnumFacing.Axis>create("axis",
             EnumFacing.Axis.class, EnumFacing.Axis.X, EnumFacing.Axis.Z);
@@ -230,11 +229,6 @@ public class BlockModPortal extends BlockBreakable implements IHasModel {
 
             DivineRPG.proxy.spawnParticle(worldIn, portalParticle, d0, d1, d2, d3, d4, d5);
         }
-    }
-
-    @Override
-    public void registerModels() {
-        DivineRPG.proxy.registerItemRenderer(Item.getItemFromBlock(this), 0, name);
     }
 
     @Override

--- a/src/main/java/divinerpg/objects/blocks/BlockModSapling.java
+++ b/src/main/java/divinerpg/objects/blocks/BlockModSapling.java
@@ -6,7 +6,6 @@ import divinerpg.DivineRPG;
 import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModBlocks;
 import divinerpg.registry.ModItems;
-import divinerpg.utils.IHasModel;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockBush;
 import net.minecraft.block.IGrowable;
@@ -25,7 +24,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.gen.feature.WorldGenerator;
 import net.minecraftforge.event.terraingen.TerrainGen;
 
-public class BlockModSapling extends BlockBush implements IGrowable, IHasModel {
+public class BlockModSapling extends BlockBush implements IGrowable {
     public static final PropertyInteger STAGE = PropertyInteger.create("stage", 0, 1);
     protected static final AxisAlignedBB SAPLING_AABB = new AxisAlignedBB(0.09999999403953552D, 0.0D,
             0.09999999403953552D, 0.8999999761581421D, 0.800000011920929D, 0.8999999761581421D);
@@ -120,11 +119,6 @@ public class BlockModSapling extends BlockBush implements IGrowable, IHasModel {
     @Override
     protected BlockStateContainer createBlockState() {
         return new BlockStateContainer(this, new IProperty[] { STAGE });
-    }
-
-    @Override
-    public void registerModels() {
-        DivineRPG.proxy.registerItemRenderer(Item.getItemFromBlock(this), 0, "inventory");
     }
 
     @Override

--- a/src/main/java/divinerpg/objects/blocks/BlockModSlab.java
+++ b/src/main/java/divinerpg/objects/blocks/BlockModSlab.java
@@ -2,11 +2,9 @@ package divinerpg.objects.blocks;
 
 import java.util.Random;
 
-import divinerpg.DivineRPG;
 import divinerpg.enums.WoodType;
 import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModBlocks;
-import divinerpg.utils.IHasModel;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockSlab;
 import net.minecraft.block.material.Material;
@@ -21,7 +19,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
-public abstract class BlockModSlab extends BlockSlab implements IHasModel {
+public abstract class BlockModSlab extends BlockSlab  {
     public static final PropertyEnum<WoodType> VARIANT = PropertyEnum.<WoodType>create("variant", WoodType.class);
 
     private Block single;
@@ -108,9 +106,4 @@ public abstract class BlockModSlab extends BlockSlab implements IHasModel {
     }
 
     protected abstract Block getSingle();
-
-    @Override
-    public void registerModels() {
-        DivineRPG.proxy.registerItemRenderer(Item.getItemFromBlock(this), 0, "inventory");
-    }
 }

--- a/src/main/java/divinerpg/objects/blocks/BlockModSpawner.java
+++ b/src/main/java/divinerpg/objects/blocks/BlockModSpawner.java
@@ -1,20 +1,17 @@
 package divinerpg.objects.blocks;
 
-import divinerpg.DivineRPG;
 import divinerpg.Reference;
 import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModBlocks;
 import divinerpg.registry.ModItems;
-import divinerpg.utils.IHasModel;
 import net.minecraft.block.BlockMobSpawner;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityMobSpawner;
 import net.minecraft.world.World;
 
-public class BlockModSpawner extends BlockMobSpawner implements IHasModel {
+public class BlockModSpawner extends BlockMobSpawner  {
     protected String mobName;
 
     public BlockModSpawner(String name, String mobName) {
@@ -42,10 +39,5 @@ public class BlockModSpawner extends BlockMobSpawner implements IHasModel {
         spawner.readFromNBT(compound2);
         spawner.markDirty();
         return spawner;
-    }
-
-    @Override
-    public void registerModels() {
-        DivineRPG.proxy.registerItemRenderer(Item.getItemFromBlock(this), 0, "inventory");
     }
 }

--- a/src/main/java/divinerpg/objects/blocks/BlockModStairs.java
+++ b/src/main/java/divinerpg/objects/blocks/BlockModStairs.java
@@ -1,16 +1,13 @@
 package divinerpg.objects.blocks;
 
-import divinerpg.DivineRPG;
 import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModBlocks;
 import divinerpg.registry.ModItems;
-import divinerpg.utils.IHasModel;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockStairs;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 
-public class BlockModStairs extends BlockStairs implements IHasModel {
+public class BlockModStairs extends BlockStairs  {
 
     public BlockModStairs(Block base, String name) {
         super(base.getDefaultState());
@@ -21,10 +18,5 @@ public class BlockModStairs extends BlockStairs implements IHasModel {
 
         ModBlocks.BLOCKS.add(this);
         ModItems.ITEMS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
-    }
-
-    @Override
-    public void registerModels() {
-        DivineRPG.proxy.registerItemRenderer(Item.getItemFromBlock(this), 0, "inventory");
     }
 }

--- a/src/main/java/divinerpg/objects/blocks/BlockModTorch.java
+++ b/src/main/java/divinerpg/objects/blocks/BlockModTorch.java
@@ -7,10 +7,8 @@ import divinerpg.enums.ParticleType;
 import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModBlocks;
 import divinerpg.registry.ModItems;
-import divinerpg.utils.IHasModel;
 import net.minecraft.block.BlockTorch;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
@@ -18,7 +16,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class BlockModTorch extends BlockTorch implements IHasModel {
+public class BlockModTorch extends BlockTorch  {
     private ParticleType flameParticle;
 
     public BlockModTorch(String name, ParticleType particle) {
@@ -48,10 +46,5 @@ public class BlockModTorch extends BlockTorch implements IHasModel {
             d2 = d2 + 0.27D * (double) enumfacing1.getFrontOffsetZ();
         }
         DivineRPG.proxy.spawnParticle(worldIn, flameParticle, d0, d1, d2, 0.0D, 0.0D, 0.0D);
-    }
-
-    @Override
-    public void registerModels() {
-        DivineRPG.proxy.registerItemRenderer(Item.getItemFromBlock(this), 0, "inventory");
     }
 }

--- a/src/main/java/divinerpg/objects/blocks/BlockModVine.java
+++ b/src/main/java/divinerpg/objects/blocks/BlockModVine.java
@@ -1,15 +1,12 @@
 package divinerpg.objects.blocks;
 
-import divinerpg.DivineRPG;
 import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModBlocks;
 import divinerpg.registry.ModItems;
-import divinerpg.utils.IHasModel;
 import net.minecraft.block.BlockVine;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 
-public class BlockModVine extends BlockVine implements IHasModel {
+public class BlockModVine extends BlockVine {
 
     public BlockModVine(String name) {
         super();
@@ -24,10 +21,5 @@ public class BlockModVine extends BlockVine implements IHasModel {
 
         ModBlocks.BLOCKS.add(this);
         ModItems.ITEMS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
-    }
-
-    @Override
-    public void registerModels() {
-        DivineRPG.proxy.registerItemRenderer(Item.getItemFromBlock(this), 0, "inventory");
     }
 }

--- a/src/main/java/divinerpg/objects/blocks/BlockStatue.java
+++ b/src/main/java/divinerpg/objects/blocks/BlockStatue.java
@@ -96,11 +96,6 @@ public class BlockStatue extends BlockMod implements ITileEntityProvider {
         worldIn.setBlockState(pos, state.withProperty(FACING, placer.getHorizontalFacing().getOpposite()), 2);
     }
 
-    @Override
-    public void registerModels() {
-        DivineRPG.proxy.registerItemRenderer(Item.getItemFromBlock(this), 0, "inventory");
-    }
-
     private void setDefaultFacing(World worldIn, BlockPos pos, IBlockState state) {
         if (!worldIn.isRemote) {
             IBlockState iblockstate = worldIn.getBlockState(pos.north());

--- a/src/main/java/divinerpg/objects/blocks/BlockStupidSpawner.java
+++ b/src/main/java/divinerpg/objects/blocks/BlockStupidSpawner.java
@@ -1,18 +1,15 @@
 package divinerpg.objects.blocks;
 
-import divinerpg.DivineRPG;
 import divinerpg.objects.blocks.tile.entity.TileEntityStupidSpawner;
 import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModBlocks;
 import divinerpg.registry.ModItems;
-import divinerpg.utils.IHasModel;
 import net.minecraft.block.BlockMobSpawner;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
-public class BlockStupidSpawner extends BlockMobSpawner implements IHasModel {
+public class BlockStupidSpawner extends BlockMobSpawner  {
     protected String mobName;
     protected boolean spawnParticles;
 
@@ -43,10 +40,5 @@ public class BlockStupidSpawner extends BlockMobSpawner implements IHasModel {
 
     protected void setSpawnParticles(TileEntityStupidSpawner spawner) {
         spawner.setSpawnParticles(spawnParticles);
-    }
-
-    @Override
-    public void registerModels() {
-        DivineRPG.proxy.registerItemRenderer(Item.getItemFromBlock(this), 0, "inventory");
     }
 }

--- a/src/main/java/divinerpg/objects/blocks/arcana/BlockArcanaDoor.java
+++ b/src/main/java/divinerpg/objects/blocks/arcana/BlockArcanaDoor.java
@@ -89,9 +89,4 @@ public class BlockArcanaDoor extends BlockModDoor {
                                   EntityPlayer player) {
         return new ItemStack(this);
     }
-
-    @Override
-    public void registerModels() {
-        DivineRPG.proxy.registerItemRenderer(Item.getItemFromBlock(this), 0, "inventory");
-    }
 }

--- a/src/main/java/divinerpg/objects/blocks/arcana/BlockModAltar.java
+++ b/src/main/java/divinerpg/objects/blocks/arcana/BlockModAltar.java
@@ -1,21 +1,18 @@
 package divinerpg.objects.blocks.arcana;
 
-import divinerpg.DivineRPG;
 import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModBlocks;
 import divinerpg.registry.ModItems;
-import divinerpg.utils.IHasModel;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 
-public abstract class BlockModAltar extends BlockContainer implements ITileEntityProvider, IHasModel {
+public abstract class BlockModAltar extends BlockContainer implements ITileEntityProvider {
     protected static final AxisAlignedBB AABB_BLOCK = new AxisAlignedBB(0.0D, 0.0D, 0.0D, 1.0D, 0.9D, 1.0D);
 
     public BlockModAltar(String name) {
@@ -42,10 +39,5 @@ public abstract class BlockModAltar extends BlockContainer implements ITileEntit
     @Override
     public boolean isFullCube(IBlockState state) {
         return false;
-    }
-
-    @Override
-    public void registerModels() {
-        DivineRPG.proxy.registerItemRenderer(Item.getItemFromBlock(this), 0, "inventory");
     }
 }

--- a/src/main/java/divinerpg/objects/blocks/twilight/BlockModDoublePlant.java
+++ b/src/main/java/divinerpg/objects/blocks/twilight/BlockModDoublePlant.java
@@ -1,10 +1,8 @@
 package divinerpg.objects.blocks.twilight;
 
-import divinerpg.DivineRPG;
 import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModBlocks;
 import divinerpg.registry.ModItems;
-import divinerpg.utils.IHasModel;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockBush;
 import net.minecraft.block.SoundType;
@@ -28,7 +26,7 @@ import net.minecraftforge.common.IPlantable;
 import java.util.Random;
 
 public class BlockModDoublePlant extends BlockBush
-        implements IHasModel, IPlantable, net.minecraftforge.common.IShearable {
+        implements IPlantable, net.minecraftforge.common.IShearable {
     public static final PropertyEnum<BlockModDoublePlant.EnumBlockHalf> HALF = PropertyEnum.create(
             "half", BlockModDoublePlant.EnumBlockHalf.class);
     protected static final AxisAlignedBB DOUBLE_PLANT_AABB = new AxisAlignedBB(0.1D, 0.0D, 0.1D, 0.9D, 1.0D, 0.9D);
@@ -151,11 +149,6 @@ public class BlockModDoublePlant extends BlockBush
         public String getName() {
             return this == UPPER ? "upper" : "lower";
         }
-    }
-
-    @Override
-    public void registerModels() {
-        DivineRPG.proxy.registerItemRenderer(Item.getItemFromBlock(this), 0, "inventory");
     }
 
     public Block getGrass(){

--- a/src/main/java/divinerpg/objects/blocks/twilight/BlockTwilightFlower.java
+++ b/src/main/java/divinerpg/objects/blocks/twilight/BlockTwilightFlower.java
@@ -1,15 +1,12 @@
 package divinerpg.objects.blocks.twilight;
 
-import divinerpg.DivineRPG;
 import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModBlocks;
 import divinerpg.registry.ModItems;
-import divinerpg.utils.IHasModel;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockBush;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
@@ -17,7 +14,7 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.IPlantable;
 
-public class BlockTwilightFlower extends BlockBush implements IHasModel, IPlantable {
+public class BlockTwilightFlower extends BlockBush implements IPlantable {
     private Block grass;
     private AxisAlignedBB size;
 
@@ -26,10 +23,10 @@ public class BlockTwilightFlower extends BlockBush implements IHasModel, IPlanta
     }
 
     /**
-     * @param width - sets the width of flower. Can't be lass/equals zero
+     * @param width  - sets the width of flower. Can't be lass/equals zero
      * @param height - sets the height of flower. Can't be less/equals zero
      */
-    public BlockTwilightFlower(String name, Block grass, double width, double height){
+    public BlockTwilightFlower(String name, Block grass, double width, double height) {
         setRegistryName(name);
         setUnlocalizedName(name);
         this.grass = grass;
@@ -40,7 +37,7 @@ public class BlockTwilightFlower extends BlockBush implements IHasModel, IPlanta
         ModBlocks.BLOCKS.add(this);
         ModItems.ITEMS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
 
-        if (width <= 0 || height <= 0){
+        if (width <= 0 || height <= 0) {
             throw new RuntimeException("Width or height cannot be less/equals zero!");
         }
 
@@ -102,10 +99,5 @@ public class BlockTwilightFlower extends BlockBush implements IHasModel, IPlanta
     @Override
     public net.minecraftforge.common.EnumPlantType getPlantType(net.minecraft.world.IBlockAccess world, BlockPos pos) {
         return net.minecraftforge.common.EnumPlantType.Plains;
-    }
-
-    @Override
-    public void registerModels() {
-        DivineRPG.proxy.registerItemRenderer(Item.getItemFromBlock(this), 0, "inventory");
     }
 }

--- a/src/main/java/divinerpg/objects/blocks/twilight/BlockTwilightGrass.java
+++ b/src/main/java/divinerpg/objects/blocks/twilight/BlockTwilightGrass.java
@@ -2,11 +2,9 @@ package divinerpg.objects.blocks.twilight;
 
 import java.util.Random;
 
-import divinerpg.DivineRPG;
 import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModBlocks;
 import divinerpg.registry.ModItems;
-import divinerpg.utils.IHasModel;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockBush;
 import net.minecraft.block.SoundType;
@@ -21,7 +19,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.IPlantable;
 
 public class BlockTwilightGrass extends BlockBush
-        implements IHasModel, IPlantable, net.minecraftforge.common.IShearable {
+        implements IPlantable, net.minecraftforge.common.IShearable {
     private Block grass;
 
     public BlockTwilightGrass(String name, Block grass) {
@@ -83,10 +81,5 @@ public class BlockTwilightGrass extends BlockBush
     @Override
     public NonNullList<ItemStack> onSheared(ItemStack item, IBlockAccess world, BlockPos pos, int fortune) {
         return NonNullList.withSize(1, new ItemStack(this, 1));
-    }
-
-    @Override
-    public void registerModels() {
-        DivineRPG.proxy.registerItemRenderer(Item.getItemFromBlock(this), 0, "inventory");
     }
 }

--- a/src/main/java/divinerpg/objects/blocks/vanilla/BlockAltarOfCorruption.java
+++ b/src/main/java/divinerpg/objects/blocks/vanilla/BlockAltarOfCorruption.java
@@ -9,7 +9,6 @@ import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModBlocks;
 import divinerpg.registry.ModItems;
 import divinerpg.registry.ModTriggers;
-import divinerpg.utils.IHasModel;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.MapColor;
 import net.minecraft.block.material.Material;
@@ -17,7 +16,6 @@ import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumBlockRenderType;
@@ -31,7 +29,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class BlockAltarOfCorruption extends BlockContainer implements IHasModel {
+public class BlockAltarOfCorruption extends BlockContainer {
     protected static final AxisAlignedBB AABB = new AxisAlignedBB(0.0D, 0.0D, 0.0D, 1.0D, 0.75D, 1.0D);
 
     public BlockAltarOfCorruption(String name) {
@@ -118,10 +116,5 @@ public class BlockAltarOfCorruption extends BlockContainer implements IHasModel 
     @Override
     public BlockFaceShape getBlockFaceShape(IBlockAccess worldIn, IBlockState state, BlockPos pos, EnumFacing face) {
         return face == EnumFacing.DOWN ? BlockFaceShape.SOLID : BlockFaceShape.UNDEFINED;
-    }
-
-    @Override
-    public void registerModels() {
-        DivineRPG.proxy.registerItemRenderer(Item.getItemFromBlock(this), 0, "inventory");
     }
 }

--- a/src/main/java/divinerpg/objects/blocks/vanilla/BlockMobPumpkin.java
+++ b/src/main/java/divinerpg/objects/blocks/vanilla/BlockMobPumpkin.java
@@ -1,11 +1,9 @@
 package divinerpg.objects.blocks.vanilla;
 
-import divinerpg.DivineRPG;
 import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModBlocks;
 import divinerpg.registry.ModItems;
 import divinerpg.registry.ModSounds;
-import divinerpg.utils.IHasModel;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockHorizontal;
 import net.minecraft.block.SoundType;
@@ -16,7 +14,6 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.SoundEvents;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
@@ -27,7 +24,7 @@ import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
-public class BlockMobPumpkin extends BlockHorizontal implements IHasModel {
+public class BlockMobPumpkin extends BlockHorizontal {
 
     public BlockMobPumpkin(String name) {
         super(Material.GOURD);
@@ -108,11 +105,6 @@ public class BlockMobPumpkin extends BlockHorizontal implements IHasModel {
             }
         }
         return true;
-    }
-
-    @Override
-    public void registerModels() {
-        DivineRPG.proxy.registerItemRenderer(Item.getItemFromBlock(this), 0, "inventory");
     }
 
     @Override

--- a/src/main/java/divinerpg/objects/blocks/vanilla/BlockModFence.java
+++ b/src/main/java/divinerpg/objects/blocks/vanilla/BlockModFence.java
@@ -1,22 +1,19 @@
 package divinerpg.objects.blocks.vanilla;
 
-import divinerpg.DivineRPG;
 import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModBlocks;
 import divinerpg.registry.ModItems;
-import divinerpg.utils.IHasModel;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockFence;
 import net.minecraft.block.BlockFenceGate;
 import net.minecraft.block.material.MapColor;
 import net.minecraft.block.material.Material;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 
-public class BlockModFence extends BlockFence implements IHasModel {
+public class BlockModFence extends BlockFence  {
 	public BlockModFence(MapColor mapColor, String name) {
 		super(Material.WOOD, mapColor);
 		setUnlocalizedName(name);
@@ -36,10 +33,5 @@ public class BlockModFence extends BlockFence implements IHasModel {
 		Block block = world.getBlockState(other).getBlock();
 
 		return block instanceof BlockFence || block instanceof BlockFenceGate;
-	}
-
-	@Override
-	public void registerModels() {
-		DivineRPG.proxy.registerItemRenderer(Item.getItemFromBlock(this), 0, "inventory");
 	}
 }

--- a/src/main/java/divinerpg/objects/items/base/ItemBlockDoor.java
+++ b/src/main/java/divinerpg/objects/items/base/ItemBlockDoor.java
@@ -1,8 +1,5 @@
 package divinerpg.objects.items.base;
 
-import divinerpg.DivineRPG;
-import divinerpg.registry.DivineRPGTabs;
-import divinerpg.utils.IHasModel;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockDoor;
 import net.minecraft.block.SoundType;

--- a/src/main/java/divinerpg/objects/items/base/ItemDivineArmor.java
+++ b/src/main/java/divinerpg/objects/items/base/ItemDivineArmor.java
@@ -12,7 +12,6 @@ import divinerpg.enums.EnumArmor;
 import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModItems;
 import divinerpg.utils.ChatFormats;
-import divinerpg.utils.IHasModel;
 import divinerpg.utils.TokenHelper;
 import divinerpg.utils.TooltipLocalizer;
 import net.minecraft.client.util.ITooltipFlag;
@@ -28,7 +27,7 @@ import net.minecraftforge.common.ISpecialArmor;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class ItemDivineArmor extends net.minecraft.item.ItemArmor implements ISpecialArmor, IHasModel {
+public class ItemDivineArmor extends net.minecraft.item.ItemArmor implements ISpecialArmor {
     protected double damageReduction;
     protected boolean unbreakable;
     protected int fullReduction;
@@ -163,13 +162,6 @@ public class ItemDivineArmor extends net.minecraft.item.ItemArmor implements ISp
     @Override
     public boolean isDamageable() {
         return !unbreakable;
-    }
-
-    @Override
-    public void registerModels() {
-        if (!armorMaterial.isOverriden()) {
-            DivineRPG.proxy.registerItemRenderer(this, 0, name);
-        }
     }
 
     protected String getDefaultItemName(String material, EntityEquipmentSlot slot) {

--- a/src/main/java/divinerpg/objects/items/base/ItemMod.java
+++ b/src/main/java/divinerpg/objects/items/base/ItemMod.java
@@ -1,9 +1,7 @@
 package divinerpg.objects.items.base;
 
-import divinerpg.DivineRPG;
 import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModItems;
-import divinerpg.utils.IHasModel;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
@@ -13,7 +11,7 @@ import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumHand;
 import net.minecraft.world.World;
 
-public class ItemMod extends Item implements IHasModel {
+public class ItemMod extends Item  {
     protected int healAmount = 0;
     protected String name;
 
@@ -42,11 +40,6 @@ public class ItemMod extends Item implements IHasModel {
         } else {
             return super.onItemRightClick(world, player, hand);
         }
-    }
-
-    @Override
-    public void registerModels() {
-        DivineRPG.proxy.registerItemRenderer(this, 0, name);
     }
 
     public ItemMod setHealAmount(int healAmount) {

--- a/src/main/java/divinerpg/objects/items/base/ItemModAxe.java
+++ b/src/main/java/divinerpg/objects/items/base/ItemModAxe.java
@@ -4,10 +4,8 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
-import divinerpg.DivineRPG;
 import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModItems;
-import divinerpg.utils.IHasModel;
 import divinerpg.utils.TooltipLocalizer;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.item.ItemAxe;
@@ -16,7 +14,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class ItemModAxe extends ItemAxe implements IHasModel {
+public class ItemModAxe extends ItemAxe  {
 
 	private String name;
 
@@ -40,10 +38,5 @@ public class ItemModAxe extends ItemAxe implements IHasModel {
 		} else {
 			infoList.add(TooltipLocalizer.infiniteUses());
 		}
-	}
-
-	@Override
-	public void registerModels() {
-		DivineRPG.proxy.registerItemRenderer(this, 0, name);
 	}
 }

--- a/src/main/java/divinerpg/objects/items/base/ItemModBow.java
+++ b/src/main/java/divinerpg/objects/items/base/ItemModBow.java
@@ -1,12 +1,10 @@
 package divinerpg.objects.items.base;
 
-import divinerpg.DivineRPG;
 import divinerpg.enums.ArrowType;
 import divinerpg.enums.ArrowType.ArrowSpecial;
 import divinerpg.objects.entities.entity.projectiles.EntityDivineArrow;
 import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModItems;
-import divinerpg.utils.IHasModel;
 import divinerpg.utils.TooltipLocalizer;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -27,7 +25,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import javax.annotation.Nullable;
 import java.util.List;
 
-public class ItemModBow extends ItemBow implements IHasModel {
+public class ItemModBow extends ItemBow  {
     private net.minecraft.util.SoundEvent shootSound = SoundEvents.ENTITY_ARROW_SHOOT;
     public static final int DEFAULT_MAX_USE_DURATION = 72000;
     protected ArrowType arrowType;
@@ -216,9 +214,4 @@ public class ItemModBow extends ItemBow implements IHasModel {
 //        this.vethean = true;
 //        return this;
 //    }
-
-    @Override
-    public void registerModels() {
-        DivineRPG.proxy.registerItemRenderer(this, 0, name);
-    }
 }

--- a/src/main/java/divinerpg/objects/items/base/ItemModFood.java
+++ b/src/main/java/divinerpg/objects/items/base/ItemModFood.java
@@ -4,11 +4,9 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
-import divinerpg.DivineRPG;
 import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModItems;
 import divinerpg.utils.ChatFormats;
-import divinerpg.utils.IHasModel;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
@@ -18,7 +16,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class ItemModFood extends ItemFood implements IHasModel {
+public class ItemModFood extends ItemFood  {
 	public String name;
 
 	public ItemModFood(int healAmount, float saturation, boolean isWolfFood, String name) {
@@ -45,10 +43,5 @@ public class ItemModFood extends ItemFood implements IHasModel {
 		if (entityLiving instanceof EntityPlayer && item.getItem() == ModItems.chickenDinner) {
 		}
 		return item;
-	}
-
-	@Override
-	public void registerModels() {
-		DivineRPG.proxy.registerItemRenderer(this, 0, name);
 	}
 }

--- a/src/main/java/divinerpg/objects/items/base/ItemModHoe.java
+++ b/src/main/java/divinerpg/objects/items/base/ItemModHoe.java
@@ -4,10 +4,8 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
-import divinerpg.DivineRPG;
 import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModItems;
-import divinerpg.utils.IHasModel;
 import divinerpg.utils.TooltipLocalizer;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.item.ItemHoe;
@@ -16,7 +14,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class ItemModHoe extends ItemHoe implements IHasModel {
+public class ItemModHoe extends ItemHoe  {
 
     private String name;
 
@@ -38,10 +36,5 @@ public class ItemModHoe extends ItemHoe implements IHasModel {
         } else {
             infoList.add(TooltipLocalizer.infiniteUses());
         }
-    }
-
-    @Override
-    public void registerModels() {
-        DivineRPG.proxy.registerItemRenderer(this, 0, name);
     }
 }

--- a/src/main/java/divinerpg/objects/items/base/ItemModPickaxe.java
+++ b/src/main/java/divinerpg/objects/items/base/ItemModPickaxe.java
@@ -4,10 +4,8 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
-import divinerpg.DivineRPG;
 import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModItems;
-import divinerpg.utils.IHasModel;
 import divinerpg.utils.TooltipLocalizer;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.item.ItemPickaxe;
@@ -16,7 +14,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class ItemModPickaxe extends ItemPickaxe implements IHasModel {
+public class ItemModPickaxe extends ItemPickaxe  {
 	private String name;
 
 	public ItemModPickaxe(ToolMaterial material, String name) {
@@ -39,10 +37,5 @@ public class ItemModPickaxe extends ItemPickaxe implements IHasModel {
 			infoList.add(TooltipLocalizer.infiniteUses());
 		}
 
-	}
-
-	@Override
-	public void registerModels() {
-		DivineRPG.proxy.registerItemRenderer(this, 0, name);
 	}
 }

--- a/src/main/java/divinerpg/objects/items/base/ItemModSeeds.java
+++ b/src/main/java/divinerpg/objects/items/base/ItemModSeeds.java
@@ -1,9 +1,7 @@
 package divinerpg.objects.items.base;
 
-import divinerpg.DivineRPG;
 import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModItems;
-import divinerpg.utils.IHasModel;
 import net.minecraft.advancements.CriteriaTriggers;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
@@ -18,7 +16,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.IPlantable;
 
-public class ItemModSeeds extends Item implements IPlantable, IHasModel {
+public class ItemModSeeds extends Item implements IPlantable {
     public String name;
     public Block crop;
     public Block soil;
@@ -72,10 +70,5 @@ public class ItemModSeeds extends Item implements IPlantable, IHasModel {
     @Override
     public net.minecraft.block.state.IBlockState getPlant(net.minecraft.world.IBlockAccess world, BlockPos pos) {
         return this.crop.getDefaultState();
-    }
-
-    @Override
-    public void registerModels() {
-        DivineRPG.proxy.registerItemRenderer(this, 0, name);
     }
 }

--- a/src/main/java/divinerpg/objects/items/base/ItemModShovel.java
+++ b/src/main/java/divinerpg/objects/items/base/ItemModShovel.java
@@ -4,10 +4,8 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
-import divinerpg.DivineRPG;
 import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModItems;
-import divinerpg.utils.IHasModel;
 import divinerpg.utils.TooltipLocalizer;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.item.ItemSpade;
@@ -16,7 +14,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class ItemModShovel extends ItemSpade implements IHasModel {
+public class ItemModShovel extends ItemSpade  {
 
 	private String name;
 
@@ -40,10 +38,4 @@ public class ItemModShovel extends ItemSpade implements IHasModel {
 			infoList.add(TooltipLocalizer.infiniteUses());
 		}
 	}
-
-	@Override
-	public void registerModels() {
-		DivineRPG.proxy.registerItemRenderer(this, 0, name);
-	}
-
 }

--- a/src/main/java/divinerpg/objects/items/base/ItemModSword.java
+++ b/src/main/java/divinerpg/objects/items/base/ItemModSword.java
@@ -4,10 +4,8 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
-import divinerpg.DivineRPG;
 import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModItems;
-import divinerpg.utils.IHasModel;
 import divinerpg.utils.TooltipLocalizer;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.Entity;
@@ -20,7 +18,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class ItemModSword extends ItemSword implements IHasModel {
+public class ItemModSword extends ItemSword  {
 
     private String name;
     private ToolMaterial material;
@@ -70,10 +68,5 @@ public class ItemModSword extends ItemSword implements IHasModel {
     }
 
     protected void addAdditionalInformation(List<String> list) {
-    }
-
-    @Override
-    public void registerModels() {
-        DivineRPG.proxy.registerItemRenderer(this, 0, name);
     }
 }

--- a/src/main/java/divinerpg/objects/items/twilight/ItemTwilightSeeds.java
+++ b/src/main/java/divinerpg/objects/items/twilight/ItemTwilightSeeds.java
@@ -1,8 +1,6 @@
 package divinerpg.objects.items.twilight;
 
-import divinerpg.DivineRPG;
 import divinerpg.registry.DivineRPGTabs;
-import divinerpg.utils.IHasModel;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemSeeds;
@@ -15,7 +13,7 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.EnumPlantType;
 
-public class ItemTwilightSeeds extends ItemSeeds implements IHasModel {
+public class ItemTwilightSeeds extends ItemSeeds  {
     private Block grass, crop;
     String name;
 
@@ -49,10 +47,5 @@ public class ItemTwilightSeeds extends ItemSeeds implements IHasModel {
         } else {
             return EnumActionResult.FAIL;
         }
-    }
-
-    @Override
-    public void registerModels() {
-        DivineRPG.proxy.registerItemRenderer(this, 0, name);
     }
 }

--- a/src/main/java/divinerpg/objects/items/vanilla/ItemShickaxe.java
+++ b/src/main/java/divinerpg/objects/items/vanilla/ItemShickaxe.java
@@ -10,7 +10,6 @@ import com.google.common.collect.Sets;
 import divinerpg.DivineRPG;
 import divinerpg.registry.DivineRPGTabs;
 import divinerpg.registry.ModItems;
-import divinerpg.utils.IHasModel;
 import divinerpg.utils.TooltipLocalizer;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockDirt;
@@ -32,7 +31,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class ItemShickaxe extends ItemTool implements IHasModel {
+public class ItemShickaxe extends ItemTool  {
     private static final Set<Block> EFFECTIVE_ON = Sets.newHashSet(Blocks.ACTIVATOR_RAIL, Blocks.COAL_ORE,
             Blocks.COBBLESTONE, Blocks.DETECTOR_RAIL, Blocks.DIAMOND_BLOCK, Blocks.DIAMOND_ORE,
             Blocks.DOUBLE_STONE_SLAB, Blocks.GOLDEN_RAIL, Blocks.GOLD_BLOCK, Blocks.GOLD_ORE, Blocks.ICE,
@@ -169,10 +168,5 @@ public class ItemShickaxe extends ItemTool implements IHasModel {
             worldIn.setBlockState(pos, state, 11);
             stack.damageItem(1, player);
         }
-    }
-
-    @Override
-    public void registerModels() {
-        DivineRPG.proxy.registerItemRenderer(this, 0, name);
     }
 }

--- a/src/main/java/divinerpg/proxy/ClientProxy.java
+++ b/src/main/java/divinerpg/proxy/ClientProxy.java
@@ -134,31 +134,6 @@ public class ClientProxy extends CommonProxy {
     }
 
     @Override
-    public void registerItemRenderer(final Item item, final int meta, final String id) {
-        ModelLoader.setCustomModelResourceLocation(item, meta,
-                new ModelResourceLocation(item.getRegistryName(), "inventory"));
-        if (item.equals(Item.getItemFromBlock(ModBlocks.frostedChest))) {
-            item.setTileEntityItemStackRenderer(new RenderItemFrostedChest());
-        } else if (item.equals(Item.getItemFromBlock(ModBlocks.presentBox))) {
-            item.setTileEntityItemStackRenderer(new RenderItemPresentBox());
-        } else if (item.equals(Item.getItemFromBlock(ModBlocks.boneChest))) {
-            item.setTileEntityItemStackRenderer(new RenderItemBoneChest());
-        } else if (item.equals(Item.getItemFromBlock(ModBlocks.demonFurnace))) {
-            item.setTileEntityItemStackRenderer(new RenderItemDemonFurnace());
-        } else if (item instanceof ItemBlock && ((ItemBlock) item).getBlock() instanceof BlockStatue) {
-            item.setTileEntityItemStackRenderer(new RenderItemStatue());
-        } else if (item.equals(Item.getItemFromBlock(ModBlocks.edenChest))) {
-            item.setTileEntityItemStackRenderer(new RenderItemEdenChest());
-        } else if (item.equals(Item.getItemFromBlock(ModBlocks.arcaniumExtractor))) {
-            item.setTileEntityItemStackRenderer(new RenderItemArcaniumExtractor());
-        } else if (item.equals(Item.getItemFromBlock(ModBlocks.dramixAltar))) {
-            item.setTileEntityItemStackRenderer(new RenderItemDramixAltar());
-        } else if (item.equals(Item.getItemFromBlock(ModBlocks.parasectaAltar))) {
-            item.setTileEntityItemStackRenderer(new RenderItemParasectaAltar());
-        }
-    }
-
-    @Override
     public void RegisterTileEntityRender() {
         ClientRegistry.bindTileEntitySpecialRenderer(TileEntityDramixAltar.class, new RenderDramixAltar());
         ClientRegistry.bindTileEntitySpecialRenderer(TileEntityParasectaAltar.class, new RenderParasectaAltar());

--- a/src/main/java/divinerpg/registry/ModItems.java
+++ b/src/main/java/divinerpg/registry/ModItems.java
@@ -78,12 +78,16 @@ import divinerpg.objects.items.vanilla.ItemVileStorm;
 import divinerpg.utils.ChatFormats;
 import divinerpg.utils.GenerateJSON;
 import divinerpg.utils.ToolMaterialMod;
+import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.init.MobEffects;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.Item;
 import net.minecraft.potion.PotionEffect;
+import net.minecraftforge.client.event.ModelRegistryEvent;
+import net.minecraftforge.client.model.ModelLoader;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 public class ModItems {
     public static final List<Item> ITEMS = new ArrayList<Item>();
@@ -791,4 +795,7 @@ public class ModItems {
     public static void CreateJSONs() {
         GenerateJSON.generateItemModelJSONs();
     }
+
+
+
 }

--- a/src/main/java/divinerpg/utils/GenerateJSON.java
+++ b/src/main/java/divinerpg/utils/GenerateJSON.java
@@ -147,7 +147,7 @@ public class GenerateJSON {
             }
 
             Map<String, Object> json = new HashMap<>();
-            if (item instanceof IHasModel) {
+            if (true) {
                 Map<String, Object> textures = new HashMap<>();
                 if (item instanceof ItemMeriksMissile) {
                     json.put("parent", "item/handheld");

--- a/src/main/java/divinerpg/utils/IHasModel.java
+++ b/src/main/java/divinerpg/utils/IHasModel.java
@@ -1,9 +1,0 @@
-package divinerpg.utils;
-
-/**
- * Created by LiteWolf101 on Feb
- * /21/2019
- */
-public interface IHasModel {
-    public void registerModels();
-}


### PR DESCRIPTION
Keeping the model registration within the block class is unnecessary and just over complicates stuff. Also doesn't help that the "registerModels" method from that interface pretty much always had the same code in it, just spread out over multiple different classes. 

Better to just move that same code `ModelLoader.setCustomModelResourceLocation(item, 0, new ModelResourceLocation(item.getRegistryName(), "inventory"));` to a separate place and use it on everything and instead of just inserting it into every separate block/item class and forcing said blocks/items themselves to call upon it.