### PR TITLE
Fixed wrong coloring of Arcane Bar due to another mods

### DIFF
--- a/src/main/java/divinerpg/client/ArcanaRenderer.java
+++ b/src/main/java/divinerpg/client/ArcanaRenderer.java
@@ -5,6 +5,7 @@ import divinerpg.config.Config;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiIngame;
 import net.minecraft.client.gui.ScaledResolution;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -17,13 +18,16 @@ public class ArcanaRenderer {
     public static boolean regen;
 
     @SubscribeEvent
-    public void onRender(RenderGameOverlayEvent.Text event) {
-        onTickRender();
+    public void onRender(RenderGameOverlayEvent.Post event) {
+        if(event.getType() == RenderGameOverlayEvent.ElementType.ALL) {
+            onTickRender();
+        }
     }
 
     private void onTickRender() {
-        Config cfg = new Config();
         if (mc.currentScreen == null) {
+            GlStateManager.color(1.0F, 1.0F, 1.0F);//resets color
+
             GuiIngame gig = mc.ingameGUI;
             ScaledResolution scaledresolution = new ScaledResolution(mc);
             int i = scaledresolution.getScaledWidth();


### PR DESCRIPTION
Arcane Bar was changing its color due to some mods don't reset color after doing some stuff, like TheOneProbe's Overlay do with custom colors.
Also moved to Post event to prevent it from possible affecting on vanilla stuff and from being less affected from other mods.